### PR TITLE
Improve parallel scaling

### DIFF
--- a/include/Global.h
+++ b/include/Global.h
@@ -8,6 +8,7 @@
 #ifdef SUPPORT_LIBYT
 #include <libyt.h>
 #endif
+#include "GatherTree.h"
 
 
 // **********************************************************************************************************
@@ -18,7 +19,8 @@
 
 // 1. common global variables
 // ============================================================================================================
-extern AMR_t     *amr;                                // AMR tree structure
+extern AMR_t     *amr;                                // local AMR tree structure
+extern LB_GlobalTree *GlobalTree;                     // global AMR tree structure
 extern double     Time[NLEVEL];                       // "present"  physical time at each level
 extern double     Time_Prev[NLEVEL];                  // "previous" physical time at each level
 extern double     dTime_AllLv[NLEVEL];                // current evolution physical time interval at each level

--- a/src/Init/End_MemFree.cpp
+++ b/src/Init/End_MemFree.cpp
@@ -94,6 +94,10 @@ void End_MemFree()
    delete [] UM_IC_RefineRegion;    UM_IC_RefineRegion = NULL;
 
 
+// 10. global AMR structure
+   delete GlobalTree;   GlobalTree = NULL;
+
+
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "done\n" );
 
 } // FUNCTION : End_MemFree

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -222,7 +222,7 @@ void Init_GAMER( int *argc, char ***argv )
 #  endif // #ifdef PARTICLE
 
 
-// initialize the AMR structure and fluid field
+// initialize the local AMR structure and grid fields
    switch ( OPT__INIT )
    {
       case INIT_BY_FUNCTION :    Init_ByFunction();   break;
@@ -233,6 +233,13 @@ void Init_GAMER( int *argc, char ***argv )
 
       default : Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "OPT__INIT", OPT__INIT );
    }
+
+
+// initialize the global AMR structure if required
+#  if ( ELBDM_SCHEME == ELBDM_HYBRID )
+   delete GlobalTree;   // in case it has been allocated already
+   GlobalTree = new LB_GlobalTree;
+#  endif
 
 
 // ensure B field consistency on the shared interfaces between sibling patches

--- a/src/LoadBalance/LB_Init_LoadBalance.cpp
+++ b/src/LoadBalance/LB_Init_LoadBalance.cpp
@@ -293,6 +293,13 @@ void LB_Init_LoadBalance( const bool Redistribute, const bool SendGridData, cons
    }
 
 
+// 8. construct the global AMR structure if required
+#  if ( ELBDM_SCHEME == ELBDM_HYBRID )
+   delete GlobalTree;   // in case it has been allocated already
+   GlobalTree = new LB_GlobalTree;
+#  endif
+
+
    if ( MPI_Rank == 0 )
    {
       char lv_str[MAX_STRING];

--- a/src/LoadBalance/LB_Refine.cpp
+++ b/src/LoadBalance/LB_Refine.cpp
@@ -110,6 +110,7 @@ void LB_Refine( const int FaLv )
    SwitchFinerLevelsToWaveScheme = Recv;
 # endif // # if ( ELBDM_SCHEME == ELBDM_HYBRID )
 
+
 // 3. get the magnetic field on the coarse-fine interfaces for the divergence-free interpolation
 // ==========================================================================================
 #  ifdef MHD
@@ -194,8 +195,8 @@ void LB_Refine( const int FaLv )
 #  endif
 
 
-
-// (c1.3.6) convert density/phase to density/real part/imaginary part in hybrid scheme if we switch the level from Phase to wave
+// 7. convert density/phase to density/real part/imaginary part in hybrid scheme if we switch the level from fluid to wave
+// ==========================================================================================
 #  if ( ELBDM_SCHEME == ELBDM_HYBRID )
    if ( SwitchFinerLevelsToWaveScheme ) {
       for (int ChildLv = SonLv; ChildLv <= TOP_LEVEL; ++ChildLv) {
@@ -254,13 +255,14 @@ void LB_Refine( const int FaLv )
    } // if ( SwitchFinerLevelsToWaveScheme )
 #   endif // #if ( MODEL == ELBDM && ELBDM_SCHEME == ELBDM_HYBRID)
 
-// 7. miscellaneous
+
+// 8. miscellaneous
 // ==========================================================================================
-// 7.1 reset LB_CutPoint to the default values (-1) if SonLv has been totally removed
+// 8.1 reset LB_CutPoint to the default values (-1) if SonLv has been totally removed
    if ( NPatchTotal[SonLv] == 0 )
       for (int r=0; r<MPI_NRank+1; r++)   amr->LB->CutPoint[SonLv][r] = -1;
 
-// 7.2 free memory
+// 8.2 free memory
    if ( NewPID_Home == NULL  &&  NNew_Home != 0 )
       Aux_Error( ERROR_INFO, "%s has not been allocated !!\n", "NewPID_Home"   );
 
@@ -316,6 +318,14 @@ void LB_Refine( const int FaLv )
 #  ifdef PARTICLE
    delete [] RefineS2F_Send_PIDList;
    delete [] RefineF2S_Send_PIDList;
+#  endif
+
+
+// 9. construct the global AMR structure if required
+// ==========================================================================================
+#  if ( ELBDM_SCHEME == ELBDM_HYBRID )
+   delete GlobalTree;   // in case it has been allocated already
+   GlobalTree = new LB_GlobalTree;
 #  endif
 
 } // FUNCTION : LB_Refine

--- a/src/Main/InvokeSolver.cpp
+++ b/src/Main/InvokeSolver.cpp
@@ -196,14 +196,6 @@ void InvokeSolver( const Solver_t TSolver, const int lv, const double TimeNew, c
    NPG[ArrayID] = ( NPG_Max < NTotal ) ? NPG_Max : NTotal;
 
 
-   LB_GlobalTree* GlobalTree = NULL;
-
-#  if ( ELBDM_SCHEME == ELBDM_HYBRID )
-// construct global tree structure
-   LB_GlobalTree GlobalTreeObject;
-
-   GlobalTree = &GlobalTreeObject;
-#  endif
 
 #  if ( GRAMFE_SCHEME == GRAMFE_MATMUL )
 // evaluate time evolution matrix ( once per level per timestep )

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -17,6 +17,7 @@
 // 1. common global variables
 // =======================================================================================================
 AMR_t               *amr = NULL;
+LB_GlobalTree       *GlobalTree = NULL;
 
 double               Time[NLEVEL]           = { 0.0 };
 double               dTime_AllLv[NLEVEL]    = { 0.0 };

--- a/src/Model_ELBDM/ELBDM_GetTimeStep_Hybrid_Velocity.cpp
+++ b/src/Model_ELBDM/ELBDM_GetTimeStep_Hybrid_Velocity.cpp
@@ -4,6 +4,9 @@
 
 static real GetMaxVelocity( const int lv, const bool ExcludeWaveCells);
 
+
+
+
 //-------------------------------------------------------------------------------------------------------
 // Function    :  ELBDM_GetTimeStep_Hybrid_Velocity
 // Description :  Estimate the evolution time-step via the CFL condition from the Hamilton-Jacobi equation
@@ -75,9 +78,6 @@ real GetMaxVelocity( const int lv, const bool ExcludeWaveCells )
    _dh      = (real)1.0/amr->dh[lv];
    _dh2     = (real)0.5*_dh;
 
-// construct global tree structure
-   LB_GlobalTree GlobalTree;
-
 #  pragma omp parallel private( Flu_Array, V, GradS, \
                                 im, ip, jm, jp, km, kp, I, J, K)
    {
@@ -101,7 +101,7 @@ real GetMaxVelocity( const int lv, const bool ExcludeWaveCells )
          for (int i=NGhost; i<Size_Flu-NGhost; i++)    {  im = i - 1;    ip = i + 1;   I = i - NGhost;
 
 //          skip velocities of cells that have a wave counterpart on the refined levels
-            long GID0                   = GlobalTree.PID2GID(PID0, lv);
+            long GID0                   = GlobalTree->PID2GID(PID0, lv);
             bool DoNotCalculateVelocity = false;
             if ( ExcludeWaveCells )
             {
@@ -109,7 +109,7 @@ real GetMaxVelocity( const int lv, const bool ExcludeWaveCells )
 //             however, ELBDM_HasWaveCounterpart automatically returns False if (I, J, K) is outside of the patch GID0 + LocalID
                for (int LocalID=0; LocalID<8; LocalID++ )
                {
-                  DoNotCalculateVelocity |= ELBDM_HasWaveCounterpart( I, J, K, GID0, GID0 + LocalID, GlobalTree );
+                  DoNotCalculateVelocity |= ELBDM_HasWaveCounterpart( I, J, K, GID0, GID0 + LocalID, *GlobalTree );
                }
             }
 

--- a/src/Refine/Refine.cpp
+++ b/src/Refine/Refine.cpp
@@ -1151,8 +1151,6 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
    } // for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
 
 
-
-
 // free memory
    delete [] Flu_CData1D;
    delete [] Flu_FData1D;
@@ -1172,6 +1170,7 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
    for (int m=1; m<28; m++)   amr->NPatchComma[lv+1][m] = amr->num[lv+1];
 
 
+
 // d. refine buffer patches
 // ------------------------------------------------------------------------------------------------
    Refine_Buffer( lv, BufSonTable, BufGrandTable );
@@ -1182,6 +1181,7 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
       delete [] BufGrandTable;
       delete [] BufSonTable;
    }
+
 
 
 // e. re-construct tables and sibling relations
@@ -1224,7 +1224,9 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
 // get the total number of patches at lv+1
    Mis_GetTotalPatchNumber( lv+1 );
 
-// convert density/phase to density/real part/imaginary part in hybrid scheme when we switch the level from fluid to wave
+
+// f. convert density/phase to density/real part/imaginary part in hybrid scheme when we switch the level from fluid to wave
+// ------------------------------------------------------------------------------------------------
 #  if ( ELBDM_SCHEME == ELBDM_HYBRID )
    if ( SwitchFinerLevelsToWaveScheme ) {
       for (int ChildLv = lv + 1; ChildLv <= TOP_LEVEL; ++ChildLv) {
@@ -1281,8 +1283,16 @@ void Refine( const int lv, const UseLBFunc_t UseLBFunc )
          } // for (int PID=0; PID < amr->NPatchComma[ChildLv][27]; PID++)
       } // for (int ChildLv = lv + 1; ChildLv <= TOP_LEVEL; ++ChildLv)
    } // if ( SwitchFinerToWaveScheme )
+#  endif // #if ( ELBDM_SCHEME == ELBDM_HYBRID )
 
-#   endif // #if ( MODEL == ELBDM && ELBDM_SCHEME == ELBDM_HYBRID)
+
+
+// g. construct the global AMR structure if required
+// ------------------------------------------------------------------------------------------------
+#  if ( ELBDM_SCHEME == ELBDM_HYBRID )
+   delete GlobalTree;   // in case it has been allocated already
+   GlobalTree = new LB_GlobalTree;
+#  endif
 
 } // FUNCTION : Refine
 


### PR DESCRIPTION
### Issue
- Reconstructing the global AMR structure (i.e., `LB_GlobalTree GlobalTree`) is not only time-consuming but also doesn't scale with the number of processes. As a result, it can have a serious impact on parallel scalability.
- We reconstruct the global AMR structure in both `InvokeSolver()` (for _all_ solvers) and `ELBDM_GetTimeStep_Hybrid_Velocity()`, which is unnecessary if the grid structure hasn't changed.

### Solution
- Reconstructing the global AMR structure only when the grid structure changes. Specifically, it is now done in the following routines instead of `InvokeSolver()` and `ELBDM_GetTimeStep_Hybrid_Velocity()`.
  - `LB_Init_LoadBalance()`
  - `LB_Refine()`
  - `Refine()`

### Results
![fig_scaling](https://github.com/KunkelAlexander/my-gamer-fork/assets/18057331/ae3c751c-ea73-458c-b524-4f4e2e4fe15d)

The scaling is significantly improved after applying the above solution. The results are based on the following test.
- `VortexPairLinear` test
- `1024^3` base-level resolution and two refinement levels (with `OPT__FLAG_RHO`)
- Only use the fluid scheme
- No GPU
- On the eureka cluster using 1-16 nodes. All materials can be accessed at `/work1/shared/optimize_hybrid_scheme_scaling`.

### Notes
- The above solution only alleviates but does not completely resolve the issue since it just reconstructs the global AMR structure less frequently but the reconstruction routine `LB_GatherTree()` is still time-consuming and doesn't scale well. Consequently, the issue will likely reemerge when using more and more nodes. A better solution will be optimizing `LB_GatherTree()` in terms of both performance and scalability.
- I've confirmed that the results of the `LSS_Hybrid` test (light halo) are bitwise-identical before and after applying the above fix.